### PR TITLE
docs: add missing dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Preview - this is a draft of everything I've learned in a year working with agen
 --> 
 
 
-# 12 Factor Agents - Principles for building reliable LLM applications
+# 12-Factor Agents - Principles for building reliable LLM applications
 
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
 


### PR DESCRIPTION
**Reason:** The hyphen connects "12" and "factor" to form a single compound adjective modifying "agents". This is standard grammatical practice (like "five-star hotel") and clearer. It also aligns with the original "12-Factor App" naming convention.