### PR TITLE
Add snippet about error handling being removed from primary context

### DIFF
--- a/content/factor-09-compact-errors.md
+++ b/content/factor-09-compact-errors.md
@@ -78,9 +78,7 @@ Benefits:
 
 I'm sure you will find that if you do this TOO much, your agent will start to spin out and might repeat the same error over and over again. 
 
-That's where [factor 8 - own your control flow](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-08-own-your-control-flow.md) and [factor 3 - own your context building](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md) come in - you don't need to just put the raw error back on, you can completely restructure how it's represented, remove previous events from the context window, or whatever deterministic thing you find works to get an agent back on track.
-
-Along with the last point, it is also important to consider when error handling calls should be abstracted away from the primary control flow and context window. For example, if a tool call fails and the agent retries twice before getting something that works, the erroneous outputs and error handling messages can often simply be replaced by the final successful output. This can help keep context usage down and reduce the risk of the agent getting distracted from the main goal.
+That's where [factor 8 - own your control flow](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-08-own-your-control-flow.md) and [factor 3 - own your context building](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md) come in - you don't need to just put the raw error back on, you can completely restructure how it's represented, remove previous events from the context window, or whatever deterministic thing you find works to get an agent back on track. Often, error handling calls can be completely removed from the primary control flow and context window. This can help keep context usage down and reduce the risk of the agent getting distracted from the main goal.
 
 But the number one way to prevent error spin-outs is to embrace [factor 10 - small, focused agents](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-10-small-focused-agents.md).
 

--- a/content/factor-09-compact-errors.md
+++ b/content/factor-09-compact-errors.md
@@ -78,7 +78,9 @@ Benefits:
 
 I'm sure you will find that if you do this TOO much, your agent will start to spin out and might repeat the same error over and over again. 
 
-That's where [factor 8 - own your control flow](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-08-own-your-control-flow.md) and [factor 3 - own your context building](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md) come in - you don't need to just put the raw error back on, you can completely restructure how it's represented, remove previous events from the context window, or whatever deterministic thing you find works to get an agent back on track. 
+That's where [factor 8 - own your control flow](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-08-own-your-control-flow.md) and [factor 3 - own your context building](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md) come in - you don't need to just put the raw error back on, you can completely restructure how it's represented, remove previous events from the context window, or whatever deterministic thing you find works to get an agent back on track.
+
+Along with the last point, it is also important to consider when error handling calls should be abstracted away from the primary control flow and context window. For example, if a tool call fails and the agent retries twice before getting something that works, the erroneous outputs and error handling messages can often simply be replaced by the final successful output. This can help keep context usage down and reduce the risk of the agent getting distracted from the main goal.
 
 But the number one way to prevent error spin-outs is to embrace [factor 10 - small, focused agents](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-10-small-focused-agents.md).
 


### PR DESCRIPTION
Just a minor addition to the "Compact Errors" section that error handling can often be removed from the agent's context window once a successful output is achieved. You demonstrate that in the GIF but reiterating it in the text could be good. I tried to maintain the same tone/style of the rest of the article.