### PR TITLE
Fix typo in factor-01: Change 'Hey Jeff' to 'Hey Terri' in memo

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Anyways back to the thing...
 
 ### Design Patterns for great LLM applications
 
-After digging through hundreds of AI libriaries and working with dozens of founders, my instinct is this:
+After digging through hundreds of AI libraries and working with dozens of founders, my instinct is this:
 
 1. There are some core things that make agents great
 2. Going all in on a framework and building what is essentially a greenfield rewrite may be counter-productive

--- a/content/factor-01-natural-language-to-tool-calls.md
+++ b/content/factor-01-natural-language-to-tool-calls.md
@@ -36,7 +36,7 @@ From there, deterministic code can pick up the payload and do something with it.
 # The LLM takes natural language and returns a structured object
 nextStep = await llm.determineNextStep(
   """
-  create a payment link for $750 to Jeff 
+  create a payment link for $750 to Terri 
   for sponsoring the february AI tinkerers meetup
   """
   )

--- a/content/factor-01-natural-language-to-tool-calls.md
+++ b/content/factor-01-natural-language-to-tool-calls.md
@@ -22,7 +22,7 @@ to a structured object that describes a Stripe API call like
       "product": "prod_8675309",
       "price": "prc_09874329fds",
       "quantity": 1,
-      "memo": "Hey Jeff - see below for the payment link for the february ai tinkerers meetup"
+      "memo": "Hey Terri - see below for the payment link for the february ai tinkerers meetup"
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixed an inconsistency in the example where the memo addressed "Jeff" instead of "Terri", even though the payment link was being created for Terri.