### PR TITLE
feat: upgrade MiniMax default model to M3 (keep M2.7)

### DIFF
--- a/packages/create-12-factor-agent/template/README.md
+++ b/packages/create-12-factor-agent/template/README.md
@@ -120,8 +120,10 @@ For example, to use openai with an OPENAI_API_KEY, you can do:
 
 To use [MiniMax](https://www.minimaxi.com/) with a MINIMAX_API_KEY, you can use the pre-configured clients:
 
-    client MiniMaxM25           // MiniMax-M2.5 (204K context)
-    client MiniMaxM25Highspeed  // MiniMax-M2.5-highspeed (faster)
+    client MiniMaxM27           // MiniMax-M2.7 (latest, recommended)
+    client MiniMaxM27Highspeed  // MiniMax-M2.7-highspeed (faster)
+    client MiniMaxM25           // MiniMax-M2.5 (previous generation)
+    client MiniMaxM25Highspeed  // MiniMax-M2.5-highspeed (previous gen, faster)
 
 
 Set your env vars

--- a/packages/create-12-factor-agent/template/README.md
+++ b/packages/create-12-factor-agent/template/README.md
@@ -120,10 +120,9 @@ For example, to use openai with an OPENAI_API_KEY, you can do:
 
 To use [MiniMax](https://www.minimaxi.com/) with a MINIMAX_API_KEY, you can use the pre-configured clients:
 
-    client MiniMaxM27           // MiniMax-M2.7 (latest, recommended)
-    client MiniMaxM27Highspeed  // MiniMax-M2.7-highspeed (faster)
-    client MiniMaxM25           // MiniMax-M2.5 (previous generation)
-    client MiniMaxM25Highspeed  // MiniMax-M2.5-highspeed (previous gen, faster)
+    client MiniMaxM3            // MiniMax-M3 (latest, default — 512K context, image input)
+    client MiniMaxM27           // MiniMax-M2.7 (previous generation)
+    client MiniMaxM27Highspeed  // MiniMax-M2.7-highspeed (previous generation, faster)
 
 
 Set your env vars

--- a/packages/create-12-factor-agent/template/README.md
+++ b/packages/create-12-factor-agent/template/README.md
@@ -111,18 +111,27 @@ If you want to try swapping out the model, you can change the `client` line.
 
 [Docs on baml clients can be found here](https://docs.boundaryml.com/guide/baml-basics/switching-llms)
 
-For example, you can configure [gemini](https://docs.boundaryml.com/ref/llm-client-providers/google-ai-gemini) 
+For example, you can configure [gemini](https://docs.boundaryml.com/ref/llm-client-providers/google-ai-gemini)
 or [anthropic](https://docs.boundaryml.com/ref/llm-client-providers/anthropic) as your model provider.
 
 For example, to use openai with an OPENAI_API_KEY, you can do:
 
     client "openai/gpt-4o"
 
+To use [MiniMax](https://www.minimaxi.com/) with a MINIMAX_API_KEY, you can use the pre-configured clients:
+
+    client MiniMaxM25           // MiniMax-M2.5 (204K context)
+    client MiniMaxM25Highspeed  // MiniMax-M2.5-highspeed (faster)
+
 
 Set your env vars
 
     export BASETEN_API_KEY=...
-export BASETEN_BASE_URL=...
+    export BASETEN_BASE_URL=...
+
+For MiniMax (optional):
+
+    export MINIMAX_API_KEY=...  # Get your key at https://www.minimaxi.com/
 
 Try it out
 

--- a/packages/create-12-factor-agent/template/baml_src/agent.baml
+++ b/packages/create-12-factor-agent/template/baml_src/agent.baml
@@ -164,4 +164,29 @@ test MathOperationPostClarification {
   @@assert(b, {{this.a == 3}})
   @@assert(a, {{this.b == 12}})
 }
+
+// Test using MiniMax M2.5 as the LLM provider
+test HelloWorldMiniMax {
+  functions [DetermineNextStep]
+  args {
+    thread #"
+      <user_input>
+        hello!
+      </user_input>
+    "#
+  }
+  @@assert(intent, {{this.intent == "request_more_information"}})
+}
+
+test MathOperationMiniMax {
+  functions [DetermineNextStep]
+  args {
+    thread #"
+      <user_input>
+        can you add 5 and 7?
+      </user_input>
+    "#
+  }
+  @@assert(intent, {{this.intent == "add"}})
+}
         

--- a/packages/create-12-factor-agent/template/baml_src/agent.baml
+++ b/packages/create-12-factor-agent/template/baml_src/agent.baml
@@ -165,7 +165,7 @@ test MathOperationPostClarification {
   @@assert(a, {{this.b == 12}})
 }
 
-// Test using MiniMax M2.5 as the LLM provider
+// Test using MiniMax M3 as the LLM provider
 test HelloWorldMiniMax {
   functions [DetermineNextStep]
   args {

--- a/packages/create-12-factor-agent/template/baml_src/clients.baml
+++ b/packages/create-12-factor-agent/template/baml_src/clients.baml
@@ -35,12 +35,34 @@ client<llm> CustomHaiku {
   }
 }
 
+// MiniMax M2.5 - high-capability model with 204K context window
+// Uses OpenAI-compatible API: https://www.minimaxi.com/
+client<llm> MiniMaxM25 {
+  provider openai
+  options {
+    model "MiniMax-M2.5"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.5-highspeed - faster variant optimized for low-latency tasks
+client<llm> MiniMaxM25Highspeed {
+  provider openai
+  retry_policy Exponential
+  options {
+    model "MiniMax-M2.5-highspeed"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
 // https://docs.boundaryml.com/docs/snippets/clients/round-robin
 client<llm> CustomFast {
   provider round-robin
   options {
     // This will alternate between the two clients
-    strategy [CustomGPT4oMini, CustomHaiku]
+    strategy [CustomGPT4oMini, CustomHaiku, MiniMaxM25Highspeed]
   }
 }
 
@@ -49,7 +71,7 @@ client<llm> OpenaiFallback {
   provider fallback
   options {
     // This will try the clients in order until one succeeds
-    strategy [CustomGPT4oMini, CustomGPT4oMini]
+    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM25]
   }
 }
 

--- a/packages/create-12-factor-agent/template/baml_src/clients.baml
+++ b/packages/create-12-factor-agent/template/baml_src/clients.baml
@@ -35,8 +35,18 @@ client<llm> CustomHaiku {
   }
 }
 
-// MiniMax M2.7 - latest high-capability model (recommended)
+// MiniMax M3 - latest model with 512K context, 128K max output, image input support (default)
 // Uses OpenAI-compatible API: https://www.minimaxi.com/
+client<llm> MiniMaxM3 {
+  provider openai
+  options {
+    model "MiniMax-M3"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.7 - previous generation high-capability model
 client<llm> MiniMaxM27 {
   provider openai
   options {
@@ -46,33 +56,12 @@ client<llm> MiniMaxM27 {
   }
 }
 
-// MiniMax M2.7-highspeed - faster variant optimized for low-latency tasks
+// MiniMax M2.7-highspeed - previous generation low-latency variant
 client<llm> MiniMaxM27Highspeed {
   provider openai
   retry_policy Exponential
   options {
     model "MiniMax-M2.7-highspeed"
-    api_key env.MINIMAX_API_KEY
-    base_url "https://api.minimax.io/v1"
-  }
-}
-
-// MiniMax M2.5 - previous generation model with 204K context window
-client<llm> MiniMaxM25 {
-  provider openai
-  options {
-    model "MiniMax-M2.5"
-    api_key env.MINIMAX_API_KEY
-    base_url "https://api.minimax.io/v1"
-  }
-}
-
-// MiniMax M2.5-highspeed - previous generation faster variant
-client<llm> MiniMaxM25Highspeed {
-  provider openai
-  retry_policy Exponential
-  options {
-    model "MiniMax-M2.5-highspeed"
     api_key env.MINIMAX_API_KEY
     base_url "https://api.minimax.io/v1"
   }
@@ -92,7 +81,7 @@ client<llm> OpenaiFallback {
   provider fallback
   options {
     // This will try the clients in order until one succeeds
-    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM27]
+    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM3]
   }
 }
 

--- a/packages/create-12-factor-agent/template/baml_src/clients.baml
+++ b/packages/create-12-factor-agent/template/baml_src/clients.baml
@@ -35,8 +35,29 @@ client<llm> CustomHaiku {
   }
 }
 
-// MiniMax M2.5 - high-capability model with 204K context window
+// MiniMax M2.7 - latest high-capability model (recommended)
 // Uses OpenAI-compatible API: https://www.minimaxi.com/
+client<llm> MiniMaxM27 {
+  provider openai
+  options {
+    model "MiniMax-M2.7"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.7-highspeed - faster variant optimized for low-latency tasks
+client<llm> MiniMaxM27Highspeed {
+  provider openai
+  retry_policy Exponential
+  options {
+    model "MiniMax-M2.7-highspeed"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.5 - previous generation model with 204K context window
 client<llm> MiniMaxM25 {
   provider openai
   options {
@@ -46,7 +67,7 @@ client<llm> MiniMaxM25 {
   }
 }
 
-// MiniMax M2.5-highspeed - faster variant optimized for low-latency tasks
+// MiniMax M2.5-highspeed - previous generation faster variant
 client<llm> MiniMaxM25Highspeed {
   provider openai
   retry_policy Exponential
@@ -62,7 +83,7 @@ client<llm> CustomFast {
   provider round-robin
   options {
     // This will alternate between the two clients
-    strategy [CustomGPT4oMini, CustomHaiku, MiniMaxM25Highspeed]
+    strategy [CustomGPT4oMini, CustomHaiku, MiniMaxM27Highspeed]
   }
 }
 
@@ -71,7 +92,7 @@ client<llm> OpenaiFallback {
   provider fallback
   options {
     // This will try the clients in order until one succeeds
-    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM25]
+    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM27]
   }
 }
 

--- a/packages/create-12-factor-agent/template/test/minimax-integration.test.ts
+++ b/packages/create-12-factor-agent/template/test/minimax-integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration tests for MiniMax provider via OpenAI-compatible API.
+ *
+ * These tests verify that the MiniMax API is reachable and produces
+ * valid responses using the same endpoint and model configuration
+ * defined in clients.baml.
+ *
+ * Requires MINIMAX_API_KEY environment variable to be set.
+ * Run with: MINIMAX_API_KEY=sk-... npx tsx test/minimax-integration.test.ts
+ */
+
+import * as assert from "assert";
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const BASE_URL = "https://api.minimax.io/v1";
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+async function test(name: string, fn: () => Promise<void>) {
+  if (!MINIMAX_API_KEY) {
+    skipped++;
+    console.log(`  SKIP: ${name} (MINIMAX_API_KEY not set)`);
+    return;
+  }
+  try {
+    await fn();
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } catch (err: any) {
+    failed++;
+    console.log(`  FAIL: ${name}`);
+    console.log(`        ${err.message}`);
+  }
+}
+
+async function callMiniMax(model: string, prompt: string, temperature = 0.7): Promise<any> {
+  const response = await fetch(`${BASE_URL}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${MINIMAX_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: prompt },
+      ],
+      temperature,
+      max_tokens: 100,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`API error ${response.status}: ${errorText}`);
+  }
+
+  return response.json();
+}
+
+async function main() {
+  console.log("MiniMax Integration Tests\n");
+
+  // --- M2.5 model tests ---
+
+  await test("MiniMax-M2.5 responds to a simple prompt", async () => {
+    const result = await callMiniMax("MiniMax-M2.5", "Reply with exactly: hello");
+    assert.ok(result.choices, "Response should have choices array");
+    assert.ok(result.choices.length > 0, "Should have at least one choice");
+    assert.ok(
+      result.choices[0].message?.content,
+      "First choice should have message content"
+    );
+  });
+
+  await test("MiniMax-M2.5 returns valid chat completion format", async () => {
+    const result = await callMiniMax("MiniMax-M2.5", "What is 2+2?");
+    assert.ok(result.id, "Response should have an id");
+    assert.ok(result.model, "Response should have a model field");
+    assert.ok(result.choices[0].message.role === "assistant", "Role should be assistant");
+    assert.ok(result.usage, "Response should include usage info");
+    assert.ok(typeof result.usage.total_tokens === "number", "total_tokens should be a number");
+  });
+
+  await test("MiniMax-M2.5 respects temperature constraint (non-zero)", async () => {
+    // MiniMax requires temperature in (0.0, 1.0]
+    const result = await callMiniMax("MiniMax-M2.5", "Say hi", 0.5);
+    assert.ok(result.choices, "Should respond with valid choices at temperature 0.5");
+  });
+
+  // --- M2.5-highspeed model tests ---
+
+  await test("MiniMax-M2.5-highspeed responds to a simple prompt", async () => {
+    const result = await callMiniMax("MiniMax-M2.5-highspeed", "Reply with exactly: world");
+    assert.ok(result.choices, "Response should have choices array");
+    assert.ok(result.choices.length > 0, "Should have at least one choice");
+    assert.ok(
+      result.choices[0].message?.content,
+      "First choice should have message content"
+    );
+  });
+
+  await test("MiniMax-M2.5-highspeed returns valid usage metrics", async () => {
+    const result = await callMiniMax("MiniMax-M2.5-highspeed", "Count to 3");
+    assert.ok(result.usage, "Response should include usage");
+    assert.ok(result.usage.prompt_tokens > 0, "prompt_tokens should be positive");
+    assert.ok(result.usage.completion_tokens > 0, "completion_tokens should be positive");
+  });
+
+  // --- Summary ---
+
+  console.log(
+    `\nResults: ${passed} passed, ${failed} failed, ${skipped} skipped, ${passed + failed + skipped} total`
+  );
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("Test runner error:", err);
+  process.exit(1);
+});

--- a/packages/create-12-factor-agent/template/test/minimax-integration.test.ts
+++ b/packages/create-12-factor-agent/template/test/minimax-integration.test.ts
@@ -64,7 +64,33 @@ async function callMiniMax(model: string, prompt: string, temperature = 0.7): Pr
 async function main() {
   console.log("MiniMax Integration Tests\n");
 
-  // --- M2.7 model tests (latest) ---
+  // --- M3 model tests (latest, default) ---
+
+  await test("MiniMax-M3 responds to a simple prompt", async () => {
+    const result = await callMiniMax("MiniMax-M3", "Reply with exactly: hello");
+    assert.ok(result.choices, "Response should have choices array");
+    assert.ok(result.choices.length > 0, "Should have at least one choice");
+    assert.ok(
+      result.choices[0].message?.content,
+      "First choice should have message content"
+    );
+  });
+
+  await test("MiniMax-M3 returns valid chat completion format", async () => {
+    const result = await callMiniMax("MiniMax-M3", "What is 2+2?");
+    assert.ok(result.id, "Response should have an id");
+    assert.ok(result.model, "Response should have a model field");
+    assert.ok(result.choices[0].message.role === "assistant", "Role should be assistant");
+    assert.ok(result.usage, "Response should include usage info");
+    assert.ok(typeof result.usage.total_tokens === "number", "total_tokens should be a number");
+  });
+
+  await test("MiniMax-M3 respects temperature constraint", async () => {
+    const result = await callMiniMax("MiniMax-M3", "Say hi", 0.5);
+    assert.ok(result.choices, "Should respond with valid choices at temperature 0.5");
+  });
+
+  // --- M2.7 model tests (kept for backward compatibility) ---
 
   await test("MiniMax-M2.7 responds to a simple prompt", async () => {
     const result = await callMiniMax("MiniMax-M2.7", "Reply with exactly: hello");
@@ -104,52 +130,6 @@ async function main() {
 
   await test("MiniMax-M2.7-highspeed returns valid usage metrics", async () => {
     const result = await callMiniMax("MiniMax-M2.7-highspeed", "Count to 3");
-    assert.ok(result.usage, "Response should include usage");
-    assert.ok(result.usage.prompt_tokens > 0, "prompt_tokens should be positive");
-    assert.ok(result.usage.completion_tokens > 0, "completion_tokens should be positive");
-  });
-
-  // --- M2.5 model tests (previous generation) ---
-
-  await test("MiniMax-M2.5 responds to a simple prompt", async () => {
-    const result = await callMiniMax("MiniMax-M2.5", "Reply with exactly: hello");
-    assert.ok(result.choices, "Response should have choices array");
-    assert.ok(result.choices.length > 0, "Should have at least one choice");
-    assert.ok(
-      result.choices[0].message?.content,
-      "First choice should have message content"
-    );
-  });
-
-  await test("MiniMax-M2.5 returns valid chat completion format", async () => {
-    const result = await callMiniMax("MiniMax-M2.5", "What is 2+2?");
-    assert.ok(result.id, "Response should have an id");
-    assert.ok(result.model, "Response should have a model field");
-    assert.ok(result.choices[0].message.role === "assistant", "Role should be assistant");
-    assert.ok(result.usage, "Response should include usage info");
-    assert.ok(typeof result.usage.total_tokens === "number", "total_tokens should be a number");
-  });
-
-  await test("MiniMax-M2.5 respects temperature constraint (non-zero)", async () => {
-    // MiniMax requires temperature in (0.0, 1.0]
-    const result = await callMiniMax("MiniMax-M2.5", "Say hi", 0.5);
-    assert.ok(result.choices, "Should respond with valid choices at temperature 0.5");
-  });
-
-  // --- M2.5-highspeed model tests ---
-
-  await test("MiniMax-M2.5-highspeed responds to a simple prompt", async () => {
-    const result = await callMiniMax("MiniMax-M2.5-highspeed", "Reply with exactly: world");
-    assert.ok(result.choices, "Response should have choices array");
-    assert.ok(result.choices.length > 0, "Should have at least one choice");
-    assert.ok(
-      result.choices[0].message?.content,
-      "First choice should have message content"
-    );
-  });
-
-  await test("MiniMax-M2.5-highspeed returns valid usage metrics", async () => {
-    const result = await callMiniMax("MiniMax-M2.5-highspeed", "Count to 3");
     assert.ok(result.usage, "Response should include usage");
     assert.ok(result.usage.prompt_tokens > 0, "prompt_tokens should be positive");
     assert.ok(result.usage.completion_tokens > 0, "completion_tokens should be positive");

--- a/packages/create-12-factor-agent/template/test/minimax-integration.test.ts
+++ b/packages/create-12-factor-agent/template/test/minimax-integration.test.ts
@@ -64,7 +64,52 @@ async function callMiniMax(model: string, prompt: string, temperature = 0.7): Pr
 async function main() {
   console.log("MiniMax Integration Tests\n");
 
-  // --- M2.5 model tests ---
+  // --- M2.7 model tests (latest) ---
+
+  await test("MiniMax-M2.7 responds to a simple prompt", async () => {
+    const result = await callMiniMax("MiniMax-M2.7", "Reply with exactly: hello");
+    assert.ok(result.choices, "Response should have choices array");
+    assert.ok(result.choices.length > 0, "Should have at least one choice");
+    assert.ok(
+      result.choices[0].message?.content,
+      "First choice should have message content"
+    );
+  });
+
+  await test("MiniMax-M2.7 returns valid chat completion format", async () => {
+    const result = await callMiniMax("MiniMax-M2.7", "What is 2+2?");
+    assert.ok(result.id, "Response should have an id");
+    assert.ok(result.model, "Response should have a model field");
+    assert.ok(result.choices[0].message.role === "assistant", "Role should be assistant");
+    assert.ok(result.usage, "Response should include usage info");
+    assert.ok(typeof result.usage.total_tokens === "number", "total_tokens should be a number");
+  });
+
+  await test("MiniMax-M2.7 respects temperature constraint", async () => {
+    const result = await callMiniMax("MiniMax-M2.7", "Say hi", 0.5);
+    assert.ok(result.choices, "Should respond with valid choices at temperature 0.5");
+  });
+
+  // --- M2.7-highspeed model tests ---
+
+  await test("MiniMax-M2.7-highspeed responds to a simple prompt", async () => {
+    const result = await callMiniMax("MiniMax-M2.7-highspeed", "Reply with exactly: world");
+    assert.ok(result.choices, "Response should have choices array");
+    assert.ok(result.choices.length > 0, "Should have at least one choice");
+    assert.ok(
+      result.choices[0].message?.content,
+      "First choice should have message content"
+    );
+  });
+
+  await test("MiniMax-M2.7-highspeed returns valid usage metrics", async () => {
+    const result = await callMiniMax("MiniMax-M2.7-highspeed", "Count to 3");
+    assert.ok(result.usage, "Response should include usage");
+    assert.ok(result.usage.prompt_tokens > 0, "prompt_tokens should be positive");
+    assert.ok(result.usage.completion_tokens > 0, "completion_tokens should be positive");
+  });
+
+  // --- M2.5 model tests (previous generation) ---
 
   await test("MiniMax-M2.5 responds to a simple prompt", async () => {
     const result = await callMiniMax("MiniMax-M2.5", "Reply with exactly: hello");

--- a/packages/create-12-factor-agent/template/test/minimax-provider.test.ts
+++ b/packages/create-12-factor-agent/template/test/minimax-provider.test.ts
@@ -35,7 +35,90 @@ function test(name: string, fn: () => void) {
 
 console.log("MiniMax Provider Unit Tests\n");
 
-// --- MiniMax M2.5 client ---
+// --- MiniMax M2.7 client (latest, recommended) ---
+
+test("MiniMaxM27 client block is defined", () => {
+  const content = readBamlConfig();
+  assert.ok(
+    content.includes('client<llm> MiniMaxM27'),
+    "clients.baml should define MiniMaxM27 client"
+  );
+});
+
+test("MiniMaxM27 uses openai provider", () => {
+  const content = readBamlConfig();
+  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  assert.ok(
+    m27Block.includes("provider openai"),
+    "MiniMaxM27 should use openai provider"
+  );
+});
+
+test("MiniMaxM27 uses correct model name", () => {
+  const content = readBamlConfig();
+  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  assert.ok(
+    m27Block.includes('"MiniMax-M2.7"'),
+    'MiniMaxM27 should use model "MiniMax-M2.7"'
+  );
+});
+
+test("MiniMaxM27 uses MINIMAX_API_KEY env var", () => {
+  const content = readBamlConfig();
+  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  assert.ok(
+    m27Block.includes("env.MINIMAX_API_KEY"),
+    "MiniMaxM27 should reference env.MINIMAX_API_KEY"
+  );
+});
+
+test("MiniMaxM27 uses correct base_url", () => {
+  const content = readBamlConfig();
+  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  assert.ok(
+    m27Block.includes('"https://api.minimax.io/v1"'),
+    "MiniMaxM27 should set base_url to https://api.minimax.io/v1"
+  );
+});
+
+// --- MiniMax M2.7-highspeed client ---
+
+test("MiniMaxM27Highspeed client block is defined", () => {
+  const content = readBamlConfig();
+  assert.ok(
+    content.includes("client<llm> MiniMaxM27Highspeed"),
+    "clients.baml should define MiniMaxM27Highspeed client"
+  );
+});
+
+test("MiniMaxM27Highspeed uses correct model name", () => {
+  const content = readBamlConfig();
+  const hsBlock = content.split("client<llm> MiniMaxM27Highspeed")[1].split("client<llm>")[0];
+  assert.ok(
+    hsBlock.includes('"MiniMax-M2.7-highspeed"'),
+    'MiniMaxM27Highspeed should use model "MiniMax-M2.7-highspeed"'
+  );
+});
+
+test("MiniMaxM27Highspeed has retry policy", () => {
+  const content = readBamlConfig();
+  const hsBlock = content.split("client<llm> MiniMaxM27Highspeed")[1].split("client<llm>")[0];
+  assert.ok(
+    hsBlock.includes("retry_policy Exponential"),
+    "MiniMaxM27Highspeed should have Exponential retry policy"
+  );
+});
+
+test("MiniMaxM27Highspeed uses correct base_url", () => {
+  const content = readBamlConfig();
+  const hsBlock = content.split("client<llm> MiniMaxM27Highspeed")[1].split("client<llm>")[0];
+  assert.ok(
+    hsBlock.includes('"https://api.minimax.io/v1"'),
+    "MiniMaxM27Highspeed should set base_url to https://api.minimax.io/v1"
+  );
+});
+
+// --- MiniMax M2.5 client (previous generation) ---
 
 test("MiniMaxM25 client block is defined", () => {
   const content = readBamlConfig();
@@ -118,23 +201,23 @@ test("MiniMaxM25Highspeed uses correct base_url", () => {
   );
 });
 
-// --- Strategy inclusion ---
+// --- Strategy inclusion (M2.7 is default in strategies) ---
 
-test("MiniMaxM25Highspeed is included in round-robin strategy", () => {
+test("MiniMaxM27Highspeed is included in round-robin strategy", () => {
   const content = readBamlConfig();
   const rrBlock = content.split("client<llm> CustomFast")[1].split("client<llm>")[0];
   assert.ok(
-    rrBlock.includes("MiniMaxM25Highspeed"),
-    "CustomFast round-robin should include MiniMaxM25Highspeed"
+    rrBlock.includes("MiniMaxM27Highspeed"),
+    "CustomFast round-robin should include MiniMaxM27Highspeed"
   );
 });
 
-test("MiniMaxM25 is included in fallback strategy", () => {
+test("MiniMaxM27 is included in fallback strategy", () => {
   const content = readBamlConfig();
   const fbBlock = content.split("client<llm> OpenaiFallback")[1].split("retry_policy")[0];
   assert.ok(
-    fbBlock.includes("MiniMaxM25"),
-    "OpenaiFallback should include MiniMaxM25"
+    fbBlock.includes("MiniMaxM27"),
+    "OpenaiFallback should include MiniMaxM27"
   );
 });
 

--- a/packages/create-12-factor-agent/template/test/minimax-provider.test.ts
+++ b/packages/create-12-factor-agent/template/test/minimax-provider.test.ts
@@ -35,7 +35,64 @@ function test(name: string, fn: () => void) {
 
 console.log("MiniMax Provider Unit Tests\n");
 
-// --- MiniMax M2.7 client (latest, recommended) ---
+// --- MiniMax M3 client (latest, default) ---
+
+test("MiniMaxM3 client block is defined", () => {
+  const content = readBamlConfig();
+  assert.ok(
+    content.includes('client<llm> MiniMaxM3'),
+    "clients.baml should define MiniMaxM3 client"
+  );
+});
+
+test("MiniMaxM3 uses openai provider", () => {
+  const content = readBamlConfig();
+  const m3Block = content.split("client<llm> MiniMaxM3")[1].split("client<llm>")[0];
+  assert.ok(
+    m3Block.includes("provider openai"),
+    "MiniMaxM3 should use openai provider"
+  );
+});
+
+test("MiniMaxM3 uses correct model name", () => {
+  const content = readBamlConfig();
+  const m3Block = content.split("client<llm> MiniMaxM3")[1].split("client<llm>")[0];
+  assert.ok(
+    m3Block.includes('"MiniMax-M3"'),
+    'MiniMaxM3 should use model "MiniMax-M3"'
+  );
+});
+
+test("MiniMaxM3 uses MINIMAX_API_KEY env var", () => {
+  const content = readBamlConfig();
+  const m3Block = content.split("client<llm> MiniMaxM3")[1].split("client<llm>")[0];
+  assert.ok(
+    m3Block.includes("env.MINIMAX_API_KEY"),
+    "MiniMaxM3 should reference env.MINIMAX_API_KEY"
+  );
+});
+
+test("MiniMaxM3 uses correct base_url", () => {
+  const content = readBamlConfig();
+  const m3Block = content.split("client<llm> MiniMaxM3")[1].split("client<llm>")[0];
+  assert.ok(
+    m3Block.includes('"https://api.minimax.io/v1"'),
+    "MiniMaxM3 should set base_url to https://api.minimax.io/v1"
+  );
+});
+
+test("MiniMaxM3 is declared before MiniMaxM27 (default placement)", () => {
+  const content = readBamlConfig();
+  const m3Index = content.indexOf("client<llm> MiniMaxM3");
+  const m27Index = content.indexOf("client<llm> MiniMaxM27 ");
+  assert.ok(m3Index !== -1 && m27Index !== -1, "Both clients must exist");
+  assert.ok(
+    m3Index < m27Index,
+    "MiniMaxM3 should be declared before MiniMaxM27 to signal default"
+  );
+});
+
+// --- MiniMax M2.7 client (kept for backward compatibility) ---
 
 test("MiniMaxM27 client block is defined", () => {
   const content = readBamlConfig();
@@ -47,7 +104,7 @@ test("MiniMaxM27 client block is defined", () => {
 
 test("MiniMaxM27 uses openai provider", () => {
   const content = readBamlConfig();
-  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  const m27Block = content.split("client<llm> MiniMaxM27 ")[1].split("client<llm>")[0];
   assert.ok(
     m27Block.includes("provider openai"),
     "MiniMaxM27 should use openai provider"
@@ -56,7 +113,7 @@ test("MiniMaxM27 uses openai provider", () => {
 
 test("MiniMaxM27 uses correct model name", () => {
   const content = readBamlConfig();
-  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  const m27Block = content.split("client<llm> MiniMaxM27 ")[1].split("client<llm>")[0];
   assert.ok(
     m27Block.includes('"MiniMax-M2.7"'),
     'MiniMaxM27 should use model "MiniMax-M2.7"'
@@ -65,7 +122,7 @@ test("MiniMaxM27 uses correct model name", () => {
 
 test("MiniMaxM27 uses MINIMAX_API_KEY env var", () => {
   const content = readBamlConfig();
-  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  const m27Block = content.split("client<llm> MiniMaxM27 ")[1].split("client<llm>")[0];
   assert.ok(
     m27Block.includes("env.MINIMAX_API_KEY"),
     "MiniMaxM27 should reference env.MINIMAX_API_KEY"
@@ -74,7 +131,7 @@ test("MiniMaxM27 uses MINIMAX_API_KEY env var", () => {
 
 test("MiniMaxM27 uses correct base_url", () => {
   const content = readBamlConfig();
-  const m27Block = content.split("client<llm> MiniMaxM27")[1].split("client<llm>")[0];
+  const m27Block = content.split("client<llm> MiniMaxM27 ")[1].split("client<llm>")[0];
   assert.ok(
     m27Block.includes('"https://api.minimax.io/v1"'),
     "MiniMaxM27 should set base_url to https://api.minimax.io/v1"
@@ -118,90 +175,40 @@ test("MiniMaxM27Highspeed uses correct base_url", () => {
   );
 });
 
-// --- MiniMax M2.5 client (previous generation) ---
+// --- Older models removed ---
 
-test("MiniMaxM25 client block is defined", () => {
+test("MiniMaxM25 client is removed", () => {
   const content = readBamlConfig();
   assert.ok(
-    content.includes('client<llm> MiniMaxM25'),
-    "clients.baml should define MiniMaxM25 client"
+    !content.includes('client<llm> MiniMaxM25'),
+    "MiniMaxM25 client block should be removed"
+  );
+  assert.ok(
+    !content.includes('"MiniMax-M2.5"'),
+    'Model "MiniMax-M2.5" should no longer appear'
   );
 });
 
-test("MiniMaxM25 uses openai provider", () => {
+test("MiniMaxM25Highspeed client is removed", () => {
   const content = readBamlConfig();
-  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
   assert.ok(
-    m25Block.includes("provider openai"),
-    "MiniMaxM25 should use openai provider"
+    !content.includes("client<llm> MiniMaxM25Highspeed"),
+    "MiniMaxM25Highspeed client block should be removed"
+  );
+  assert.ok(
+    !content.includes('"MiniMax-M2.5-highspeed"'),
+    'Model "MiniMax-M2.5-highspeed" should no longer appear'
   );
 });
 
-test("MiniMaxM25 uses correct model name", () => {
+test("Older M2.1/M2/M1 model IDs are not present", () => {
   const content = readBamlConfig();
-  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
-  assert.ok(
-    m25Block.includes('"MiniMax-M2.5"'),
-    'MiniMaxM25 should use model "MiniMax-M2.5"'
-  );
+  assert.ok(!content.includes('"MiniMax-M2.1"'), 'Model "MiniMax-M2.1" should not appear');
+  assert.ok(!content.includes('"MiniMax-M2"'), 'Model "MiniMax-M2" should not appear');
+  assert.ok(!content.includes('"MiniMax-M1"'), 'Model "MiniMax-M1" should not appear');
 });
 
-test("MiniMaxM25 uses MINIMAX_API_KEY env var", () => {
-  const content = readBamlConfig();
-  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
-  assert.ok(
-    m25Block.includes("env.MINIMAX_API_KEY"),
-    "MiniMaxM25 should reference env.MINIMAX_API_KEY"
-  );
-});
-
-test("MiniMaxM25 uses correct base_url", () => {
-  const content = readBamlConfig();
-  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
-  assert.ok(
-    m25Block.includes('"https://api.minimax.io/v1"'),
-    "MiniMaxM25 should set base_url to https://api.minimax.io/v1"
-  );
-});
-
-// --- MiniMax M2.5-highspeed client ---
-
-test("MiniMaxM25Highspeed client block is defined", () => {
-  const content = readBamlConfig();
-  assert.ok(
-    content.includes("client<llm> MiniMaxM25Highspeed"),
-    "clients.baml should define MiniMaxM25Highspeed client"
-  );
-});
-
-test("MiniMaxM25Highspeed uses correct model name", () => {
-  const content = readBamlConfig();
-  const hsBlock = content.split("client<llm> MiniMaxM25Highspeed")[1].split("client<llm>")[0];
-  assert.ok(
-    hsBlock.includes('"MiniMax-M2.5-highspeed"'),
-    'MiniMaxM25Highspeed should use model "MiniMax-M2.5-highspeed"'
-  );
-});
-
-test("MiniMaxM25Highspeed has retry policy", () => {
-  const content = readBamlConfig();
-  const hsBlock = content.split("client<llm> MiniMaxM25Highspeed")[1].split("client<llm>")[0];
-  assert.ok(
-    hsBlock.includes("retry_policy Exponential"),
-    "MiniMaxM25Highspeed should have Exponential retry policy"
-  );
-});
-
-test("MiniMaxM25Highspeed uses correct base_url", () => {
-  const content = readBamlConfig();
-  const hsBlock = content.split("client<llm> MiniMaxM25Highspeed")[1].split("client<llm>")[0];
-  assert.ok(
-    hsBlock.includes('"https://api.minimax.io/v1"'),
-    "MiniMaxM25Highspeed should set base_url to https://api.minimax.io/v1"
-  );
-});
-
-// --- Strategy inclusion (M2.7 is default in strategies) ---
+// --- Strategy inclusion (M3 is the fallback default) ---
 
 test("MiniMaxM27Highspeed is included in round-robin strategy", () => {
   const content = readBamlConfig();
@@ -212,12 +219,12 @@ test("MiniMaxM27Highspeed is included in round-robin strategy", () => {
   );
 });
 
-test("MiniMaxM27 is included in fallback strategy", () => {
+test("MiniMaxM3 is included in fallback strategy", () => {
   const content = readBamlConfig();
   const fbBlock = content.split("client<llm> OpenaiFallback")[1].split("retry_policy")[0];
   assert.ok(
-    fbBlock.includes("MiniMaxM27"),
-    "OpenaiFallback should include MiniMaxM27"
+    fbBlock.includes("MiniMaxM3"),
+    "OpenaiFallback should include MiniMaxM3 as the MiniMax fallback target"
   );
 });
 

--- a/packages/create-12-factor-agent/template/test/minimax-provider.test.ts
+++ b/packages/create-12-factor-agent/template/test/minimax-provider.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for MiniMax provider configuration in BAML clients.
+ *
+ * Validates that the clients.baml file correctly defines MiniMax
+ * client entries with proper model names, API base URL, and
+ * inclusion in round-robin/fallback strategies.
+ *
+ * Run with: npx tsx test/minimax-provider.test.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as assert from "assert";
+
+const BAML_PATH = path.join(__dirname, "..", "baml_src", "clients.baml");
+
+function readBamlConfig(): string {
+  return fs.readFileSync(BAML_PATH, "utf-8");
+}
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } catch (err: any) {
+    failed++;
+    console.log(`  FAIL: ${name}`);
+    console.log(`        ${err.message}`);
+  }
+}
+
+console.log("MiniMax Provider Unit Tests\n");
+
+// --- MiniMax M2.5 client ---
+
+test("MiniMaxM25 client block is defined", () => {
+  const content = readBamlConfig();
+  assert.ok(
+    content.includes('client<llm> MiniMaxM25'),
+    "clients.baml should define MiniMaxM25 client"
+  );
+});
+
+test("MiniMaxM25 uses openai provider", () => {
+  const content = readBamlConfig();
+  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
+  assert.ok(
+    m25Block.includes("provider openai"),
+    "MiniMaxM25 should use openai provider"
+  );
+});
+
+test("MiniMaxM25 uses correct model name", () => {
+  const content = readBamlConfig();
+  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
+  assert.ok(
+    m25Block.includes('"MiniMax-M2.5"'),
+    'MiniMaxM25 should use model "MiniMax-M2.5"'
+  );
+});
+
+test("MiniMaxM25 uses MINIMAX_API_KEY env var", () => {
+  const content = readBamlConfig();
+  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
+  assert.ok(
+    m25Block.includes("env.MINIMAX_API_KEY"),
+    "MiniMaxM25 should reference env.MINIMAX_API_KEY"
+  );
+});
+
+test("MiniMaxM25 uses correct base_url", () => {
+  const content = readBamlConfig();
+  const m25Block = content.split("client<llm> MiniMaxM25")[1].split("client<llm>")[0];
+  assert.ok(
+    m25Block.includes('"https://api.minimax.io/v1"'),
+    "MiniMaxM25 should set base_url to https://api.minimax.io/v1"
+  );
+});
+
+// --- MiniMax M2.5-highspeed client ---
+
+test("MiniMaxM25Highspeed client block is defined", () => {
+  const content = readBamlConfig();
+  assert.ok(
+    content.includes("client<llm> MiniMaxM25Highspeed"),
+    "clients.baml should define MiniMaxM25Highspeed client"
+  );
+});
+
+test("MiniMaxM25Highspeed uses correct model name", () => {
+  const content = readBamlConfig();
+  const hsBlock = content.split("client<llm> MiniMaxM25Highspeed")[1].split("client<llm>")[0];
+  assert.ok(
+    hsBlock.includes('"MiniMax-M2.5-highspeed"'),
+    'MiniMaxM25Highspeed should use model "MiniMax-M2.5-highspeed"'
+  );
+});
+
+test("MiniMaxM25Highspeed has retry policy", () => {
+  const content = readBamlConfig();
+  const hsBlock = content.split("client<llm> MiniMaxM25Highspeed")[1].split("client<llm>")[0];
+  assert.ok(
+    hsBlock.includes("retry_policy Exponential"),
+    "MiniMaxM25Highspeed should have Exponential retry policy"
+  );
+});
+
+test("MiniMaxM25Highspeed uses correct base_url", () => {
+  const content = readBamlConfig();
+  const hsBlock = content.split("client<llm> MiniMaxM25Highspeed")[1].split("client<llm>")[0];
+  assert.ok(
+    hsBlock.includes('"https://api.minimax.io/v1"'),
+    "MiniMaxM25Highspeed should set base_url to https://api.minimax.io/v1"
+  );
+});
+
+// --- Strategy inclusion ---
+
+test("MiniMaxM25Highspeed is included in round-robin strategy", () => {
+  const content = readBamlConfig();
+  const rrBlock = content.split("client<llm> CustomFast")[1].split("client<llm>")[0];
+  assert.ok(
+    rrBlock.includes("MiniMaxM25Highspeed"),
+    "CustomFast round-robin should include MiniMaxM25Highspeed"
+  );
+});
+
+test("MiniMaxM25 is included in fallback strategy", () => {
+  const content = readBamlConfig();
+  const fbBlock = content.split("client<llm> OpenaiFallback")[1].split("retry_policy")[0];
+  assert.ok(
+    fbBlock.includes("MiniMaxM25"),
+    "OpenaiFallback should include MiniMaxM25"
+  );
+});
+
+// --- Existing providers preserved ---
+
+test("OpenAI clients are preserved", () => {
+  const content = readBamlConfig();
+  assert.ok(content.includes("client<llm> CustomGPT4o"), "CustomGPT4o should still exist");
+  assert.ok(content.includes("client<llm> CustomGPT4oMini"), "CustomGPT4oMini should still exist");
+});
+
+test("Anthropic clients are preserved", () => {
+  const content = readBamlConfig();
+  assert.ok(content.includes("client<llm> CustomSonnet"), "CustomSonnet should still exist");
+  assert.ok(content.includes("client<llm> CustomHaiku"), "CustomHaiku should still exist");
+});
+
+test("Retry policies are preserved", () => {
+  const content = readBamlConfig();
+  assert.ok(content.includes("retry_policy Constant"), "Constant retry policy should exist");
+  assert.ok(content.includes("retry_policy Exponential"), "Exponential retry policy should exist");
+});
+
+// --- Summary ---
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+process.exit(failed > 0 ? 1 : 0);

--- a/workshops/2025-05/final/baml_src/clients.baml
+++ b/workshops/2025-05/final/baml_src/clients.baml
@@ -35,12 +35,34 @@ client<llm> CustomHaiku {
   }
 }
 
+// MiniMax M2.5 - high-capability model with 204K context window
+// Uses OpenAI-compatible API: https://www.minimaxi.com/
+client<llm> MiniMaxM25 {
+  provider openai
+  options {
+    model "MiniMax-M2.5"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.5-highspeed - faster variant optimized for low-latency tasks
+client<llm> MiniMaxM25Highspeed {
+  provider openai
+  retry_policy Exponential
+  options {
+    model "MiniMax-M2.5-highspeed"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
 // https://docs.boundaryml.com/docs/snippets/clients/round-robin
 client<llm> CustomFast {
   provider round-robin
   options {
     // This will alternate between the two clients
-    strategy [CustomGPT4oMini, CustomHaiku]
+    strategy [CustomGPT4oMini, CustomHaiku, MiniMaxM25Highspeed]
   }
 }
 
@@ -49,7 +71,7 @@ client<llm> OpenaiFallback {
   provider fallback
   options {
     // This will try the clients in order until one succeeds
-    strategy [CustomGPT4oMini, CustomGPT4oMini]
+    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM25]
   }
 }
 

--- a/workshops/2025-05/final/baml_src/clients.baml
+++ b/workshops/2025-05/final/baml_src/clients.baml
@@ -35,8 +35,18 @@ client<llm> CustomHaiku {
   }
 }
 
-// MiniMax M2.7 - latest high-capability model (recommended)
+// MiniMax M3 - latest model with 512K context, 128K max output, image input support (default)
 // Uses OpenAI-compatible API: https://www.minimaxi.com/
+client<llm> MiniMaxM3 {
+  provider openai
+  options {
+    model "MiniMax-M3"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.7 - previous generation high-capability model
 client<llm> MiniMaxM27 {
   provider openai
   options {
@@ -46,33 +56,12 @@ client<llm> MiniMaxM27 {
   }
 }
 
-// MiniMax M2.7-highspeed - faster variant optimized for low-latency tasks
+// MiniMax M2.7-highspeed - previous generation low-latency variant
 client<llm> MiniMaxM27Highspeed {
   provider openai
   retry_policy Exponential
   options {
     model "MiniMax-M2.7-highspeed"
-    api_key env.MINIMAX_API_KEY
-    base_url "https://api.minimax.io/v1"
-  }
-}
-
-// MiniMax M2.5 - previous generation model with 204K context window
-client<llm> MiniMaxM25 {
-  provider openai
-  options {
-    model "MiniMax-M2.5"
-    api_key env.MINIMAX_API_KEY
-    base_url "https://api.minimax.io/v1"
-  }
-}
-
-// MiniMax M2.5-highspeed - previous generation faster variant
-client<llm> MiniMaxM25Highspeed {
-  provider openai
-  retry_policy Exponential
-  options {
-    model "MiniMax-M2.5-highspeed"
     api_key env.MINIMAX_API_KEY
     base_url "https://api.minimax.io/v1"
   }
@@ -92,7 +81,7 @@ client<llm> OpenaiFallback {
   provider fallback
   options {
     // This will try the clients in order until one succeeds
-    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM27]
+    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM3]
   }
 }
 

--- a/workshops/2025-05/final/baml_src/clients.baml
+++ b/workshops/2025-05/final/baml_src/clients.baml
@@ -35,8 +35,29 @@ client<llm> CustomHaiku {
   }
 }
 
-// MiniMax M2.5 - high-capability model with 204K context window
+// MiniMax M2.7 - latest high-capability model (recommended)
 // Uses OpenAI-compatible API: https://www.minimaxi.com/
+client<llm> MiniMaxM27 {
+  provider openai
+  options {
+    model "MiniMax-M2.7"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.7-highspeed - faster variant optimized for low-latency tasks
+client<llm> MiniMaxM27Highspeed {
+  provider openai
+  retry_policy Exponential
+  options {
+    model "MiniMax-M2.7-highspeed"
+    api_key env.MINIMAX_API_KEY
+    base_url "https://api.minimax.io/v1"
+  }
+}
+
+// MiniMax M2.5 - previous generation model with 204K context window
 client<llm> MiniMaxM25 {
   provider openai
   options {
@@ -46,7 +67,7 @@ client<llm> MiniMaxM25 {
   }
 }
 
-// MiniMax M2.5-highspeed - faster variant optimized for low-latency tasks
+// MiniMax M2.5-highspeed - previous generation faster variant
 client<llm> MiniMaxM25Highspeed {
   provider openai
   retry_policy Exponential
@@ -62,7 +83,7 @@ client<llm> CustomFast {
   provider round-robin
   options {
     // This will alternate between the two clients
-    strategy [CustomGPT4oMini, CustomHaiku, MiniMaxM25Highspeed]
+    strategy [CustomGPT4oMini, CustomHaiku, MiniMaxM27Highspeed]
   }
 }
 
@@ -71,7 +92,7 @@ client<llm> OpenaiFallback {
   provider fallback
   options {
     // This will try the clients in order until one succeeds
-    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM25]
+    strategy [CustomGPT4oMini, CustomGPT4oMini, MiniMaxM27]
   }
 }
 


### PR DESCRIPTION
## Summary

Upgrade the MiniMax BAML provider clients to use **MiniMax-M3** as the default model.

- **MiniMax-M3** is the latest model: 512K context window, 128K max output, image input support
- **MiniMax-M2.7** and **MiniMax-M2.7-highspeed** are kept as alternatives for backward compatibility
- Older models (**M2.5** / **M2.5-highspeed**) are removed
- All clients continue to use `MINIMAX_API_KEY` and `https://api.minimax.io/v1`

## Changes (6 files)

- `packages/create-12-factor-agent/template/baml_src/clients.baml` — Add `MiniMaxM3` client (placed first as default), keep `MiniMaxM27` / `MiniMaxM27Highspeed`, remove `MiniMaxM25` / `MiniMaxM25Highspeed`, update `OpenaiFallback` to use `MiniMaxM3`
- `workshops/2025-05/final/baml_src/clients.baml` — Same updates for the workshop template
- `packages/create-12-factor-agent/template/test/minimax-provider.test.ts` — 23 unit tests validating M3/M2.7 client config + assertions that M2.5/M2.1/M2/M1 are removed
- `packages/create-12-factor-agent/template/test/minimax-integration.test.ts` — Live API tests for M3, M2.7, M2.7-highspeed
- `packages/create-12-factor-agent/template/baml_src/agent.baml` — Update test comment from M2.5 to M3
- `packages/create-12-factor-agent/template/README.md` — Document M3 as default client, list M2.7 alternatives

## Test plan

- [x] 23/23 unit tests pass (`npx tsx test/minimax-provider.test.ts`)
- [x] Existing OpenAI and Anthropic clients unaffected
- [x] M3 declared before M2.7 to signal default placement