### PR TITLE
fix: remove duplicate content files

### DIFF
--- a/content/factor-1-natural-language-to-tool-calls.md
+++ b/content/factor-1-natural-language-to-tool-calls.md
@@ -1,1 +1,0 @@
-[Moved to factor-01-natural-language-to-tool-calls.md](./factor-01-natural-language-to-tool-calls.md)

--- a/content/factor-2-own-your-prompts.md
+++ b/content/factor-2-own-your-prompts.md
@@ -1,1 +1,0 @@
-[Moved to factor-02-own-your-prompts.md](./factor-02-own-your-prompts.md)

--- a/content/factor-3-own-your-context-window.md
+++ b/content/factor-3-own-your-context-window.md
@@ -1,1 +1,0 @@
-[Moved to factor-03-own-your-context-window.md](./factor-03-own-your-context-window.md)

--- a/content/factor-4-tools-are-structured-outputs.md
+++ b/content/factor-4-tools-are-structured-outputs.md
@@ -1,1 +1,0 @@
-[Moved to factor-04-tools-are-structured-outputs.md](./factor-04-tools-are-structured-outputs.md)

--- a/content/factor-5-unify-execution-state.md
+++ b/content/factor-5-unify-execution-state.md
@@ -1,1 +1,0 @@
-[Moved to factor-05-unify-execution-state.md](./factor-05-unify-execution-state.md)

--- a/content/factor-6-launch-pause-resume.md
+++ b/content/factor-6-launch-pause-resume.md
@@ -1,1 +1,0 @@
-[Moved to factor-06-launch-pause-resume.md](./factor-06-launch-pause-resume.md)

--- a/content/factor-7-contact-humans-with-tools.md
+++ b/content/factor-7-contact-humans-with-tools.md
@@ -1,1 +1,0 @@
-[Moved to factor-07-contact-humans-with-tools.md](./factor-07-contact-humans-with-tools.md)

--- a/content/factor-8-own-your-control-flow.md
+++ b/content/factor-8-own-your-control-flow.md
@@ -1,1 +1,0 @@
-[Moved to factor-08-own-your-control-flow.md](./factor-08-own-your-control-flow.md)

--- a/content/factor-9-compact-errors.md
+++ b/content/factor-9-compact-errors.md
@@ -1,1 +1,0 @@
-[Moved to factor-09-compact-errors.md](./factor-09-compact-errors.md)

--- a/packages/create-12-factor-agent/template/README.md
+++ b/packages/create-12-factor-agent/template/README.md
@@ -353,7 +353,7 @@ Verify tests pass
 In this section, we'll explore how to customize the prompt of the agent
 with reasoning steps.
 
-this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
 there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
 
@@ -389,7 +389,7 @@ add a field to your tool output format that includes the reasoning steps in the 
 In this section, we'll explore how to customize the context window
 of the agent.
 
-this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
 
 
 update the agent to pretty-print the Context window for the model
@@ -615,7 +615,7 @@ and `request_more_information` will be handled over email,
 then the final `done_for_now` answer will be printed back to the CLI
 
 While contrived, this is a great example of the flexibility you get from
-[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
 
 for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details.
@@ -716,7 +716,7 @@ means every time we wait for human approval, we sit in a loop
 polling until the human response if received.
 
 That's obviously not ideal, especially for production workloads,
-so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
 by updating the server to end processing after contacting a human, and use webhooks to receive the results.
 
 

--- a/workshops/2025-05-17/walkthrough.md
+++ b/workshops/2025-05-17/walkthrough.md
@@ -1103,7 +1103,7 @@ Verify tests pass
 In this section, we'll explore how to customize the prompt of the agent
 with reasoning steps.
 
-this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
 there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
 
@@ -1167,7 +1167,7 @@ add a field to your tool output format that includes the reasoning steps in the 
 In this section, we'll explore how to customize the context window
 of the agent.
 
-this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
 
 
 update the agent to pretty-print the Context window for the model
@@ -1847,7 +1847,7 @@ and `request_more_information` will be handled over email,
 then the final `done_for_now` answer will be printed back to the CLI
 
 While contrived, this is a great example of the flexibility you get from
-[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
 
 for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details.
@@ -2102,7 +2102,7 @@ means every time we wait for human approval, we sit in a loop
 polling until the human response if received.
 
 That's obviously not ideal, especially for production workloads,
-so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
 by updating the server to end processing after contacting a human, and use webhooks to receive the results.
 
 

--- a/workshops/2025-05-17/walkthrough.yaml
+++ b/workshops/2025-05-17/walkthrough.yaml
@@ -331,7 +331,7 @@ sections:
       In this section, we'll explore how to customize the prompt of the agent
       with reasoning steps.
 
-      this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+      this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
       there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
 
@@ -363,7 +363,7 @@ sections:
       In this section, we'll explore how to customize the context window
       of the agent.
 
-      this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+      this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
 
     steps:
       - text: |
@@ -563,7 +563,7 @@ sections:
       then the final `done_for_now` answer will be printed back to the CLI
 
       While contrived, this is a great example of the flexibility you get from
-      [factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+      [factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
     steps:
       - text: "for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details."
@@ -650,7 +650,7 @@ sections:
       polling until the human response if received.
 
       That's obviously not ideal, especially for production workloads,
-      so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+      so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
       by updating the server to end processing after contacting a human, and use webhooks to receive the results.
 
     steps:

--- a/workshops/2025-05/sections/06-customize-prompt/README.md
+++ b/workshops/2025-05/sections/06-customize-prompt/README.md
@@ -3,7 +3,7 @@
 In this section, we'll explore how to customize the prompt of the agent
 with reasoning steps.
 
-this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
 there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
 

--- a/workshops/2025-05/sections/07-context-window/README.md
+++ b/workshops/2025-05/sections/07-context-window/README.md
@@ -3,7 +3,7 @@
 In this section, we'll explore how to customize the context window
 of the agent.
 
-this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
 
 
 update the agent to pretty-print the Context window for the model

--- a/workshops/2025-05/sections/11-humanlayer-approval/README.md
+++ b/workshops/2025-05/sections/11-humanlayer-approval/README.md
@@ -9,7 +9,7 @@ and `request_more_information` will be handled over email,
 then the final `done_for_now` answer will be printed back to the CLI
 
 While contrived, this is a great example of the flexibility you get from
-[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
 
 for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details.

--- a/workshops/2025-05/sections/12-humanlayer-webhook/README.md
+++ b/workshops/2025-05/sections/12-humanlayer-webhook/README.md
@@ -5,7 +5,7 @@ means every time we wait for human approval, we sit in a loop
 polling until the human response if received.
 
 That's obviously not ideal, especially for production workloads,
-so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
 by updating the server to end processing after contacting a human, and use webhooks to receive the results. 
 
 

--- a/workshops/2025-05/sections/final/README.md
+++ b/workshops/2025-05/sections/final/README.md
@@ -334,7 +334,7 @@ Verify tests pass
 In this section, we'll explore how to customize the prompt of the agent
 with reasoning steps.
 
-this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
 there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
 
@@ -370,7 +370,7 @@ add a field to your tool output format that includes the reasoning steps in the 
 In this section, we'll explore how to customize the context window
 of the agent.
 
-this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
 
 
 update the agent to pretty-print the Context window for the model
@@ -596,7 +596,7 @@ and `request_more_information` will be handled over email,
 then the final `done_for_now` answer will be printed back to the CLI
 
 While contrived, this is a great example of the flexibility you get from
-[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
 
 for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details.
@@ -697,7 +697,7 @@ means every time we wait for human approval, we sit in a loop
 polling until the human response if received.
 
 That's obviously not ideal, especially for production workloads,
-so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
 by updating the server to end processing after contacting a human, and use webhooks to receive the results. 
 
 

--- a/workshops/2025-05/walkthrough.md
+++ b/workshops/2025-05/walkthrough.md
@@ -1028,7 +1028,7 @@ Verify tests pass
 In this section, we'll explore how to customize the prompt of the agent
 with reasoning steps.
 
-this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
 there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
 
@@ -1088,7 +1088,7 @@ add a field to your tool output format that includes the reasoning steps in the 
 In this section, we'll explore how to customize the context window
 of the agent.
 
-this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
 
 
 update the agent to pretty-print the Context window for the model
@@ -1768,7 +1768,7 @@ and `request_more_information` will be handled over email,
 then the final `done_for_now` answer will be printed back to the CLI
 
 While contrived, this is a great example of the flexibility you get from
-[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+[factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
 
 for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details.
@@ -2023,7 +2023,7 @@ means every time we wait for human approval, we sit in a loop
 polling until the human response if received.
 
 That's obviously not ideal, especially for production workloads,
-so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
 by updating the server to end processing after contacting a human, and use webhooks to receive the results. 
 
 

--- a/workshops/2025-05/walkthrough.yaml
+++ b/workshops/2025-05/walkthrough.yaml
@@ -317,7 +317,7 @@ sections:
       In this section, we'll explore how to customize the prompt of the agent
       with reasoning steps.
 
-      this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+      this is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
 
       there's a deep dive on reasoning on AI That Works [reasoning models versus reasoning steps](https://github.com/hellovai/ai-that-works/tree/main/2025-04-07-reasoning-models-vs-prompts)
       
@@ -349,7 +349,7 @@ sections:
       In this section, we'll explore how to customize the context window
       of the agent.
 
-      this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+      this is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
       
     steps:
       - text: |
@@ -549,7 +549,7 @@ sections:
       then the final `done_for_now` answer will be printed back to the CLI
 
       While contrived, this is a great example of the flexibility you get from
-      [factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-7-contact-humans-with-tools.md)
+      [factor 7 - contact humans with tools](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-07-contact-humans-with-tools.md)
 
     steps:
       - text: "for this section, we'll disable the baml logs. You can optionally enable them if you want to see more details."
@@ -636,7 +636,7 @@ sections:
       polling until the human response if received.
 
       That's obviously not ideal, especially for production workloads,
-      so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-6-launch-pause-resume.md)
+      so in this section we'll implement [factor 6 - launch / pause / resume with simple APIs](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-06-launch-pause-resume.md)
       by updating the server to end processing after contacting a human, and use webhooks to receive the results. 
 
     steps:

--- a/workshops/2025-07-16/walkthrough.yaml
+++ b/workshops/2025-07-16/walkthrough.yaml
@@ -310,7 +310,7 @@ sections:
     text: |
       In this section, we'll explore how to customize the prompt of the agent with reasoning steps.
 
-      This is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+      This is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
     steps:
       - text: |
           ## Why Add Reasoning to Prompts?
@@ -346,7 +346,7 @@ sections:
     text: |
       In this section, we'll explore how to customize the context window of the agent.
 
-      This is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+      This is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
     steps:
       - text: |
           ## Context Window Serialization

--- a/workshops/2025-07-16/walkthrough_python_enhanced.yaml
+++ b/workshops/2025-07-16/walkthrough_python_enhanced.yaml
@@ -319,7 +319,7 @@ sections:
     text: |
       In this section, we'll explore how to customize the prompt of the agent with reasoning steps.
 
-      This is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)
+      This is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)
     steps:
       - text: |
           ## Why Add Reasoning to Prompts?
@@ -360,7 +360,7 @@ sections:
     text: |
       In this section, we'll explore how to customize the context window of the agent.
 
-      This is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)
+      This is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)
     steps:
       - text: |
           ## Context Window Serialization

--- a/workshops/2025-07-16/workshop_final.ipynb
+++ b/workshops/2025-07-16/workshop_final.ipynb
@@ -1193,7 +1193,7 @@
    "source": [
     "In this section, we'll explore how to customize the prompt of the agent with reasoning steps.\n",
     "\n",
-    "This is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-2-own-your-prompts.md)\n"
+    "This is core to [factor 2 - own your prompts](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-02-own-your-prompts.md)\n"
    ]
   },
   {
@@ -1274,7 +1274,7 @@
    "source": [
     "In this section, we'll explore how to customize the context window of the agent.\n",
     "\n",
-    "This is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-3-own-your-context-window.md)\n"
+    "This is core to [factor 3 - own your context window](https://github.com/humanlayer/12-factor-agents/blob/main/content/factor-03-own-your-context-window.md)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Removes duplicate redirect files (factor-1 through factor-9 without leading zero) that pointed to the canonical factor-01 through factor-12 files.

## Changes
- Removed content/factor-1-natural-language-to-tool-calls.md
- Removed content/factor-2-own-your-prompts.md
- Removed content/factor-3-own-your-context-window.md
- Removed content/factor-4-tools-are-structured-outputs.md
- Removed content/factor-5-unify-execution-state.md
- Removed content/factor-6-launch-pause-resume.md
- Removed content/factor-7-contact-humans-with-tools.md
- Removed content/factor-8-own-your-control-flow.md
- Removed content/factor-9-compact-errors.md

These files were just redirect stubs that said '[Moved to factor-XX...]' and created duplicate content issues.