### PR TITLE
Fix typo in README: missing period and pluralize pronoun

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Deep Dive"></a>
 
 <p></p>
 
-*In the spirit of [12 Factor Apps](https://12factor.net/)*.  *The source for this project is public at https://github.com/humanlayer/12-factor-agents, and I welcome your feedback and contributions. Let's figure this out together!*
+*In the spirit of [12 Factor Apps](https://12factor.net/). *The source for this project is public at https://github.com/humanlayer/12-factor-agents, and we welcome your feedback and contributions. Let's figure this out together!*
 
 > [!TIP]
 > Missed the AI Engineer World's Fair? [Catch the talk here](https://www.youtube.com/watch?v=8kMaTybvDUw)


### PR DESCRIPTION
Fix typo in README: missing period after 12factor.net link and change I to we for collective voice